### PR TITLE
Feature/source directories

### DIFF
--- a/mate.h
+++ b/mate.h
@@ -111,6 +111,7 @@
 #define pclose _pclose
 
 /* File I/O functions */
+#define fileno _fileno
 #define fdopen _fdopen
 #define access _access
 #define unlink _unlink


### PR DESCRIPTION
Added a simple `AddDirectory` macro that goes over every file in the directory and adds it to the build.

It works by opening a pipe to a `dir` command (or ls on linux) and adding all the files it returns one by one. The filenames are allocated on the heap and passed to `AddFile` each on his own. This can (and should) be enhanced with some rules that allow only for `.c` and such files to be added and not every file but for now it will suffice.

I added the following line because it couldn't compile on my machine (using windows and gcc on mingw). I tried to solve it but couldn't so I assume it's a problem in the mainstream repo as well. If I'm incorrect feel free to ask for it's removal.
```
#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
```

As a side note, I would like to suggest to start writing proper tests for this. I tested it locally but it wouldn't do this justice. We need a proper test library that I might write myself once I have a little more free time.

Sincerely, The Simple Man. 