### PR TITLE
MacOS Test support

### DIFF
--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -1,0 +1,50 @@
+name: Run Tests MacOS
+on:
+  push:
+    paths:
+      - '**/*.c'
+      - '**/*.h'
+      - '.github/workflows/*.yml'
+permissions:
+  contents: read
+  actions: read
+jobs:
+  test-examples:
+    runs-on: macos-15
+    
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    
+    steps:
+    - name: Checkout code with submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0  
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Run tests
+      run: |
+        tests=(
+          "01-basic-build"
+          "02-custom-config"
+          "03-generic-flags"
+          "04-raylib-build"
+          "05-samurai-source-code"
+          "06-lua-source-code"
+        )
+        
+        for test in "${tests[@]}"; do
+          echo "Running test $test with ${{ matrix.compiler }}..."
+          cd ./tests/$test
+          
+          ${{ matrix.compiler }} mate.c -o mate
+          ./mate
+          
+          if [ $? -ne 0 ]; then
+            echo "Test $test failed with ${{ matrix.compiler }}"
+            exit 1
+          fi
+          cd - > /dev/null
+        done

--- a/mate.h
+++ b/mate.h
@@ -6508,7 +6508,7 @@ void EndBuild(void) {
 
 /* --- Utils Implementation --- */
 errno_t RunCommand(String command) {
-#if defined(PLATFORM_LINUX)
+#if defined(PLATFORM_LINUX) | defined(PLATFORM_MACOS)
   return system(command.data) >> 8;
 #else
   return system(command.data);

--- a/scripts/run-tests-macos.sh
+++ b/scripts/run-tests-macos.sh
@@ -45,10 +45,6 @@ if [ ! -z "$SPECIFIC_TEST" ]; then
 fi
 
 for test in "${tests[@]}"; do
-  # if [ "$COMPILER" == "tcc" ] && [ "$test" == "07-raylib-source-code" ]; then
-  #   echo "Skipping $test for TCC compiler"
-  #   continue
-  # fi
   
   echo "Running test $test with $COMPILER..."
   

--- a/scripts/run-tests-macos.sh
+++ b/scripts/run-tests-macos.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <compiler> [specific_test]"
+  echo "  compiler: gcc, clang, or tcc"
+  echo "  specific_test: Optional - Run only this test directory"
+  exit 1
+fi
+
+COMPILER=$1
+SPECIFIC_TEST=$2
+
+if ! command -v $COMPILER &> /dev/null; then
+  echo "Error: $COMPILER is not installed or not in PATH"
+  exit 1
+fi
+
+tests=(
+  "01-basic-build"
+  "02-custom-config"
+  "03-generic-flags"
+  "04-raylib-build"
+  "05-samurai-source-code"
+  "06-lua-source-code"
+  # "07-raylib-source-code" # Requires framework linking on macOS, which isnt implemented yet
+)
+
+echo "NOTE: Skipping 07-raylib-source-code test due to missing framework linking support"
+
+if [ ! -z "$SPECIFIC_TEST" ]; then
+  found=0
+  for test in "${tests[@]}"; do
+    if [ "$test" == "$SPECIFIC_TEST" ]; then
+      found=1
+      break
+    fi
+  done
+  
+  if [ $found -eq 0 ]; then
+    echo "Error: Test '$SPECIFIC_TEST' not found in test suite"
+    exit 1
+  fi
+  
+  tests=("$SPECIFIC_TEST")
+fi
+
+for test in "${tests[@]}"; do
+  # if [ "$COMPILER" == "tcc" ] && [ "$test" == "07-raylib-source-code" ]; then
+  #   echo "Skipping $test for TCC compiler"
+  #   continue
+  # fi
+  
+  echo "Running test $test with $COMPILER..."
+  
+  if [ ! -d "./tests/$test" ]; then
+    echo "Error: Test directory ./tests/$test not found"
+    continue
+  fi
+  
+  cd "./tests/$test" || continue
+  
+  rm -rf "build"
+  rm -rf "custom-dir"
+  rm -f "mate"
+  $COMPILER mate.c -o mate
+  ./mate
+  
+  result=$?
+  if [ $result -ne 0 ]; then
+    echo "❌ Test $test failed with $COMPILER (exit code: $result)"
+    cd - > /dev/null
+    exit 1
+  else
+    echo "✅ Test $test passed with $COMPILER"
+  fi
+  
+  cd - > /dev/null
+done
+
+echo "All tests completed successfully with $COMPILER! 🎉"

--- a/src/api.c
+++ b/src/api.c
@@ -1105,7 +1105,7 @@ void EndBuild(void) {
 
 /* --- Utils Implementation --- */
 errno_t RunCommand(String command) {
-#if defined(PLATFORM_LINUX)
+#if defined(PLATFORM_LINUX) | defined(PLATFORM_MACOS)
   return system(command.data) >> 8;
 #else
   return system(command.data);

--- a/tests/02-custom-config/src/main.c
+++ b/tests/02-custom-config/src/main.c
@@ -12,8 +12,6 @@ int main() {
   float z[1760]; // Depth buffer
   char b[1760];  // Character buffer
 
-  //printf("\x1b[2J"); // Clear screen
-
   while (1) {
     // Clear buffers
     memset(b, 32, 1760); // Fill with spaces
@@ -52,9 +50,6 @@ int main() {
         }
       }
     }
-
-    // Move cursor to home position
-    // printf("\x1b[H");
 
     // Display the frame and update rotation angles
     for (k = 0; k < 1761; k++) {

--- a/tests/02-custom-config/src/main.c
+++ b/tests/02-custom-config/src/main.c
@@ -12,7 +12,7 @@ int main() {
   float z[1760]; // Depth buffer
   char b[1760];  // Character buffer
 
-  printf("\x1b[2J"); // Clear screen
+  //printf("\x1b[2J"); // Clear screen
 
   while (1) {
     // Clear buffers
@@ -54,7 +54,7 @@ int main() {
     }
 
     // Move cursor to home position
-    printf("\x1b[H");
+    // printf("\x1b[H");
 
     // Display the frame and update rotation angles
     for (k = 0; k < 1761; k++) {

--- a/tests/04-raylib-build/mate.c
+++ b/tests/04-raylib-build/mate.c
@@ -32,6 +32,12 @@ i32 main(void) {
       }
     }
 
+    if (isMacOs()) {
+      AddIncludePaths(executable, "./vendor/raylib/include");
+      AddLibraryPaths(executable, "./vendor/raylib/lib/macos");
+      LinkSystemLibraries(executable, "raylib");
+    }
+
     InstallExecutable(executable);
     RunCommand(executable.outputPath);
     CreateCompileCommands(executable);

--- a/tests/05-samurai-source-code/mate.c
+++ b/tests/05-samurai-source-code/mate.c
@@ -17,7 +17,9 @@ i32 main(void) {
     RemoveFile(executable, "./src/exclude-me.c");
     RemoveFile(executable, "./src/random.c");
 
-    LinkSystemLibraries(executable, "rt");
+    if (!isMacOs()) {
+      LinkSystemLibraries(executable, "rt");
+    }
 
     InstallExecutable(executable);
 

--- a/tests/06-lua-source-code/mate.c
+++ b/tests/06-lua-source-code/mate.c
@@ -1,11 +1,25 @@
 #define MATE_IMPLEMENTATION
 #include "../../mate.h"
 
+static char *GetCFlags(void) {
+  FlagBuilder flagsBuilder = FlagBuilderCreate();
+  FlagBuilderAdd(&flagsBuilder, "fno-stack-protector", "fno-common", "march=native", "Wno-tautological-compare");
+
+  if (isWindows()) {
+    FlagBuilderAdd(&flagsBuilder, "DLUA_USE_WINDOWS");
+  } else if (isMacOs()) {
+    FlagBuilderAdd(&flagsBuilder, "DLUA_USE_MACOSX");
+  } else if (isLinux()) {
+    FlagBuilderAdd(&flagsBuilder, "DLUA_USE_LINUX");
+  }
+
+  return flagsBuilder.buffer.data;
+}
+
 i32 main(void) {
   StartBuild();
   {
-    char *cflags = "-DLUA_USE_LINUX -fno-stack-protector -fno-common -march=native -Wno-tautological-compare";
-    StaticLib staticLib = CreateStaticLib((StaticLibOptions){.output = "liblua", .std = FLAG_STD_C99, .warnings = FLAG_WARNINGS_NONE, .flags = cflags});
+    StaticLib staticLib = CreateStaticLib((StaticLibOptions){.output = "liblua", .std = FLAG_STD_C99, .warnings = FLAG_WARNINGS_NONE, .flags = GetCFlags()});
 
     AddFile(staticLib, "./src/*.c");
     RemoveFile(staticLib, "./src/lua.c");
@@ -13,7 +27,7 @@ i32 main(void) {
 
     mateInstallStaticLib(&staticLib);
 
-    Executable executable = CreateExecutable((ExecutableOptions){.output = "lua", .std = FLAG_STD_C99, .warnings = FLAG_WARNINGS_NONE, .flags = cflags});
+    Executable executable = CreateExecutable((ExecutableOptions){.output = "lua", .std = FLAG_STD_C99, .warnings = FLAG_WARNINGS_NONE, .flags = GetCFlags()});
     AddFile(executable, "./src/lua.c");
     AddLibraryPaths(executable, "./build/"); // TODO: LinkStaticLib()
     LinkSystemLibraries(executable, "lua", "m", "dl");


### PR DESCRIPTION
- **Bit shift the exit code on OSX**
- **Added MacOS raylib demo**
- **Added dynamic flags based on platform LUA**
- **Fixed macOS tests and created test-script**

Did some extended research from #17 

PATH_MAX was not a problem when using tcc or clang on MacOS.
There is however some discussions about the usage of PATH_MAX from <limit.h>
- [r/C_programming](https://www.reddit.com/r/C_Programming/comments/t9lpuu/is_it_safe_to_allocate_path_max_bytes/)
- [Insane Coding Blog](https://insanecoding.blogspot.com/2007/11/pathmax-simply-isnt.html)

Im not used to programming in C so i may not be the one to comment on this, but maybe go for a hardcoded define macro value in the mate.h header file would be the way to go. This seems like the solution most repos on GitHub has chosen.

I made a MacOS test script for running the compiler tests that work on MacOS.

All tests except the raylib source code compilation works (this is due to the requirement for framework linking on MacOS).
Couldn't figure out framework linking that would work for all compiler solutions.

The test script has been tested with:
- tcc version 0.9.28rc 2025-05-27 mob@c6792dac (AArch64 Darwin)
- Apple clang version 17.0.0 (clang-1700.0.13.3)
   - Target: arm64-apple-darwin24.5.0

gcc has not been tested due to Xcode creating a gcc compat layer with clang.

System:
- Macbook Pro
- CPU: M3 Pro
- OS: MacOS Sequoia 15.5
