### PR TITLE
Fix/macOS-Test-07

### DIFF
--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -2,49 +2,50 @@ name: Run Tests MacOS
 on:
   push:
     paths:
-      - '**/*.c'
-      - '**/*.h'
-      - '.github/workflows/*.yml'
+      - "**/*.c"
+      - "**/*.h"
+      - ".github/workflows/*.yml"
 permissions:
   contents: read
   actions: read
 jobs:
   test-examples:
     runs-on: macos-15
-    
+
     strategy:
       matrix:
         compiler: [gcc, clang]
-    
+
     steps:
-    - name: Checkout code with submodules
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0  
-        token: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Run tests
-      run: |
-        tests=(
-          "01-basic-build"
-          "02-custom-config"
-          "03-generic-flags"
-          "04-raylib-build"
-          "05-samurai-source-code"
-          "06-lua-source-code"
-        )
-        
-        for test in "${tests[@]}"; do
-          echo "Running test $test with ${{ matrix.compiler }}..."
-          cd ./tests/$test
-          
-          ${{ matrix.compiler }} mate.c -o mate
-          ./mate
-          
-          if [ $? -ne 0 ]; then
-            echo "Test $test failed with ${{ matrix.compiler }}"
-            exit 1
-          fi
-          cd - > /dev/null
-        done
+      - name: Checkout code with submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests
+        run: |
+          tests=(
+            "01-basic-build"
+            "02-custom-config"
+            "03-generic-flags"
+            "04-raylib-build"
+            "05-samurai-source-code"
+            "06-lua-source-code"
+            "07-raylib-source-code"
+          )
+
+          for test in "${tests[@]}"; do
+            echo "Running test $test with ${{ matrix.compiler }}..."
+            cd ./tests/$test
+            
+            ${{ matrix.compiler }} mate.c -o mate
+            ./mate
+            
+            if [ $? -ne 0 ]; then
+              echo "Test $test failed with ${{ matrix.compiler }}"
+              exit 1
+            fi
+            cd - > /dev/null
+          done

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        compiler: [gcc, clang]
+        compiler: [clang]
 
     steps:
       - name: Checkout code with submodules

--- a/mate.h
+++ b/mate.h
@@ -2293,9 +2293,8 @@ typedef struct {
   String ninjaBuildPath;
 } Executable;
 
-typedef struct {
-  bool needed;
-  bool weak;
+typedef enum {
+  none = 0, needed, weak
 } LinkFrameworkOptions;
 
 typedef struct {

--- a/mate.h
+++ b/mate.h
@@ -2438,7 +2438,7 @@ static void mateLinkSystemLibraries(String *targetLibs, StringVector *libs);
   } while (0)
 static void mateLinkFrameworks(String *targetLibs, StringVector *frameworks);
 
-#define LinkFrameworks(target, options, ...)                              \
+#define LinkFrameworksWithOptions(target, options, ...)                              \
   do {                                                                    \
     StringVector _frameworks = {0};                                       \
     StringVectorPushMany(_frameworks, __VA_ARGS__);                       \

--- a/mate.h
+++ b/mate.h
@@ -2460,7 +2460,7 @@ static void mateAddIncludePaths(String *targetIncludes, StringVector *vector);
     /* Cleanup */                                            \
     VecFree(_frameworks);                                    \
   } while (0)
-static void mateAddFrameworkPaths(String *targetIncludes, StringVector *vector);
+static void mateAddFrameworkPaths(String *targetIncludes, StringVector *includes);
 
 #define AddFile(target, source) mateAddFile(&(target).sources, s(source));
 static void mateAddFile(StringVector *sources, String source);
@@ -6613,7 +6613,7 @@ static void mateAddIncludePaths(String *targetIncludes, StringVector *includes) 
   *targetIncludes = builder.buffer;
 }
 
-static void mateAddFrameworkPaths(String *targetIncludes, StringVector *vector) {
+static void mateAddFrameworkPaths(String *targetIncludes, StringVector *includes) {
   Assert(isClang() || isGCC(), "AddFrameworkPaths: This function is only supported for GCC/Clang.");
 
   StringBuilder builder = StringBuilderCreate(mateState.arena);

--- a/mate.h
+++ b/mate.h
@@ -2294,6 +2294,11 @@ typedef struct {
 } Executable;
 
 typedef struct {
+  bool needed;
+  bool weak;
+} LinkFrameworkOptions;
+
+typedef struct {
   Compiler compiler;
 
   // Paths

--- a/mate.h
+++ b/mate.h
@@ -2433,6 +2433,18 @@ static void mateLinkSystemLibraries(String *targetLibs, StringVector *libs);
   } while (0)
 static void mateAddIncludePaths(String *targetIncludes, StringVector *vector);
 
+#define AddFrameworkPaths(target, ...)                       \
+  do {                                                       \
+    StringVector _frameworks = {0};                          \
+    StringVectorPushMany(_frameworks, __VA_ARGS__);          \
+    /* Frameworks are just specialized library bundles. */   \
+    mateAddFrameworkPaths(&(target).includes, &_frameworks); \
+                                                             \
+    /* Cleanup */                                            \
+    VecFree(_frameworks);                                    \
+  } while (0)
+static void mateAddFrameworkPaths(String *targetIncludes, StringVector *vector);
+
 #define AddFile(target, source) mateAddFile(&(target).sources, s(source));
 static void mateAddFile(StringVector *sources, String source);
 

--- a/mate.h
+++ b/mate.h
@@ -2422,6 +2422,18 @@ static void mateAddLibraryPaths(String *targetLibs, StringVector *libs);
   } while (0)
 static void mateLinkSystemLibraries(String *targetLibs, StringVector *libs);
 
+#define LinkFrameworks(target, ...)                        \
+  do {                                                     \
+    StringVector _frameworks = {0};                        \
+    StringVectorPushMany(_frameworks, __VA_ARGS__);        \
+    /* Frameworks are just specialized library bundles. */ \
+    mateLinkFrameworks(&(target).libs, &_frameworks);      \
+                                                           \
+    /* Cleanup */                                          \
+    VecFree(_frameworks);                                  \
+  } while (0)
+static void mateLinkFrameworks(String *targetLibs, StringVector *frameworks);
+
 #define AddIncludePaths(target, ...)                     \
   do {                                                   \
     StringVector _includes = {0};                        \

--- a/tests/07-raylib-source-code/mate.c
+++ b/tests/07-raylib-source-code/mate.c
@@ -31,7 +31,12 @@ i32 main(void) {
   StartBuild();
   {
     { // Compile static lib
-      StaticLib staticLib = CreateStaticLib((StaticLibOptions){.output = "libraylib", .flags = GetCFlags()});
+      StaticLib staticLib = CreateStaticLib((StaticLibOptions){
+          .output = "libraylib",
+          .flags = GetCFlags(),
+          // Handle linking macOS frameworks manually.
+          .libs = (!isMacOs()) ? "" : "-lm -framework Foundation -framework AppKit -framework IOKit -framework OpenGL -framework CoreVideo",
+      });
 
       AddFile(staticLib, "./src/rcore.c");
       AddFile(staticLib, "./src/utils.c");
@@ -49,16 +54,7 @@ i32 main(void) {
       if (isLinux()) {
         LinkSystemLibraries(staticLib, "GL", "rt", "dl", "m", "X11", "Xcursor", "Xext", "Xfixes", "Xi", "Xinerama", "Xrandr", "Xrender");
       }
-      if (isMacOs()) {
-        // Link regular system libraries.
-        LinkSystemLibraries(staticLib, "m");
-        // Link macOS system frameworks.
-        FlagBuilder frameworkFlagsBuilder = FlagBuilderCreate();
-        FlagBuilderAddString(&frameworkFlagsBuilder, &staticLib.libs);
-        FlagBuilderAdd(&frameworkFlagsBuilder, "framework Foundation", "framework AppKit", "framework IOKit", "framework OpenGL", "framework CoreVideo");
-        String libsAndFrameworks = frameworkFlagsBuilder.buffer;
-        staticLib.libs = libsAndFrameworks;
-      }
+      
       if (isWindows()) {
         LinkSystemLibraries(staticLib, "winmm", "gdi32", "opengl32");
       }

--- a/tests/07-raylib-source-code/mate.c
+++ b/tests/07-raylib-source-code/mate.c
@@ -79,7 +79,7 @@ i32 main(void) {
       }
       if (isMacOs()) {
         // Link regular system libraries.
-        LinkSystemLibraries(executable, "m");
+        LinkSystemLibraries(executable, "raylib", "m");
         // Link macOS system frameworks.
         FlagBuilder frameworkFlagsBuilder = FlagBuilderCreate();
         FlagBuilderAddString(&frameworkFlagsBuilder, &executable.libs);


### PR DESCRIPTION
This pull request adds [Test #07](https://github.com/TomasBorquez/mate.h/tree/30f69e995c06de66ad2f6febc2db093e58506081/tests/07-raylib-source-code) to macOS, and adds macOS compatibility to the test itself primarily by appending custom linker flags (for frameworks) to the `staticLib` and `executable` libraries.

The frameworks used are those specified in the [makefile for raylib](https://github.com/raysan5/raylib/blob/913c236487712ea6281b96990c14dea08979e727/src/Makefile#L622) and its [wiki article](https://github.com/raysan5/raylib/wiki/Working-on-macOS) describing how to build it statically on macOS.

The `-x objective-c` compiler flag is also present in the original makefile. I've added a comment noting why it's also necessary in our case.

As a final note: the corresponding GitHub action still includes `gcc` (as written) as an alternative to clang, yet the test passed with it, which tells me that's still just Apple's gcc compat-layer over clang despite the container we use including GNU clang with version suffixes (e.g. `gcc-12`). If we intend to use those versions for other tests, we should add a warning make it skip this one somehow, as simple changes are unlikely to make it pass until Proposals #12 and #6 are addressed.