### PR TITLE
Implementation od macOS linker functions

### DIFF
--- a/mate.h
+++ b/mate.h
@@ -2293,9 +2293,8 @@ typedef struct {
   String ninjaBuildPath;
 } Executable;
 
-typedef struct {
-  bool needed;
-  bool weak;
+typedef enum {
+  none = 0, needed, weak
 } LinkFrameworkOptions;
 
 typedef struct {

--- a/mate.h
+++ b/mate.h
@@ -2438,7 +2438,7 @@ static void mateLinkSystemLibraries(String *targetLibs, StringVector *libs);
   } while (0)
 static void mateLinkFrameworks(String *targetLibs, StringVector *frameworks);
 
-#define LinkFrameworks(target, options, ...)                              \
+#define LinkFrameworksWithOptions(target, options, ...)                              \
   do {                                                                    \
     StringVector _frameworks = {0};                                       \
     StringVectorPushMany(_frameworks, __VA_ARGS__);                       \

--- a/mate.h
+++ b/mate.h
@@ -2460,7 +2460,7 @@ static void mateAddIncludePaths(String *targetIncludes, StringVector *vector);
     /* Cleanup */                                            \
     VecFree(_frameworks);                                    \
   } while (0)
-static void mateAddFrameworkPaths(String *targetIncludes, StringVector *vector);
+static void mateAddFrameworkPaths(String *targetIncludes, StringVector *includes);
 
 #define AddFile(target, source) mateAddFile(&(target).sources, s(source));
 static void mateAddFile(StringVector *sources, String source);
@@ -6613,7 +6613,7 @@ static void mateAddIncludePaths(String *targetIncludes, StringVector *includes) 
   *targetIncludes = builder.buffer;
 }
 
-static void mateAddFrameworkPaths(String *targetIncludes, StringVector *vector) {
+static void mateAddFrameworkPaths(String *targetIncludes, StringVector *includes) {
   Assert(isClang() || isGCC(), "AddFrameworkPaths: This function is only supported for GCC/Clang.");
 
   StringBuilder builder = StringBuilderCreate(mateState.arena);

--- a/mate.h
+++ b/mate.h
@@ -2294,6 +2294,11 @@ typedef struct {
 } Executable;
 
 typedef struct {
+  bool needed;
+  bool weak;
+} LinkFrameworkOptions;
+
+typedef struct {
   Compiler compiler;
 
   // Paths

--- a/mate.h
+++ b/mate.h
@@ -2433,6 +2433,18 @@ static void mateLinkSystemLibraries(String *targetLibs, StringVector *libs);
   } while (0)
 static void mateAddIncludePaths(String *targetIncludes, StringVector *vector);
 
+#define AddFrameworkPaths(target, ...)                       \
+  do {                                                       \
+    StringVector _frameworks = {0};                          \
+    StringVectorPushMany(_frameworks, __VA_ARGS__);          \
+    /* Frameworks are just specialized library bundles. */   \
+    mateAddFrameworkPaths(&(target).includes, &_frameworks); \
+                                                             \
+    /* Cleanup */                                            \
+    VecFree(_frameworks);                                    \
+  } while (0)
+static void mateAddFrameworkPaths(String *targetIncludes, StringVector *vector);
+
 #define AddFile(target, source) mateAddFile(&(target).sources, s(source));
 static void mateAddFile(StringVector *sources, String source);
 

--- a/mate.h
+++ b/mate.h
@@ -2422,6 +2422,18 @@ static void mateAddLibraryPaths(String *targetLibs, StringVector *libs);
   } while (0)
 static void mateLinkSystemLibraries(String *targetLibs, StringVector *libs);
 
+#define LinkFrameworks(target, ...)                        \
+  do {                                                     \
+    StringVector _frameworks = {0};                        \
+    StringVectorPushMany(_frameworks, __VA_ARGS__);        \
+    /* Frameworks are just specialized library bundles. */ \
+    mateLinkFrameworks(&(target).libs, &_frameworks);      \
+                                                           \
+    /* Cleanup */                                          \
+    VecFree(_frameworks);                                  \
+  } while (0)
+static void mateLinkFrameworks(String *targetLibs, StringVector *frameworks);
+
 #define AddIncludePaths(target, ...)                     \
   do {                                                   \
     StringVector _includes = {0};                        \


### PR DESCRIPTION
This PR provides an implementation of linker functions for framework bundles, relying on compiler support for these, as discussed in #23.

The implementation for all the functions are based on their regular "Include" or "StaticLib" equivalents, with the exception of basic `LinkFrameworkOptions` support, which is modeled after Zig's solution, and covers the two most common alternative linking modes for framework bundles.

Since full support for modern framework bundles is only available with clang, assertions to that effect are made at the top of the corresponding functions, and specific hints are offered for users wanting to take advantage of GCC's partial support.