### PR TITLE
fix example 02 using CreateCompileCommands wrong

### DIFF
--- a/examples/02-custom-config/mate.c
+++ b/examples/02-custom-config/mate.c
@@ -21,7 +21,7 @@ i32 main(void) {
 
     RunCommand(executable.outputPath);
     // Create compile commands for better LSP support
-    CreateCompileCommands(executable.ninjaBuildPath); // executable.ninjaBuildPath is the path where the build.ninja is at, here is where we grab all the commands from
+    CreateCompileCommands(executable); // executable.ninjaBuildPath is the path where the build.ninja is at, here is where we grab all the commands from
   }
   EndBuild();
 }


### PR DESCRIPTION
the `mate.c` in the second example had a slight mistake in it preventing it from compiling. 
this one-liner fixes that.  
