### PR TITLE
feat: add StartBuildEx to be able to rebuild the script and perserve passed arguments

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,8 @@ mate.h is a build system for C written in C. It aims to provide a simple, fast, 
    - `./vendor/samurai/` - This is the mentioned rewrite of ninja in C
 4. **Amalgam:** Once you made your edits run the script:
     ```bash
-   ./scripts/run-amalgam.sh
+	cc amalgam-script.c -o amalgam-script -w # compile amalgam-script.c
+	./amalgam-script
     ```
     This will add all your changes to the main `mate.h`, which is necessary if you want to run your changes on tests
 5. **Run tests** for your platform:
@@ -80,7 +81,8 @@ You can contribute based on our existing [TODOS](../TODOS.md) or from our [issue
    - Vendor packages are automatically managed in `./vendor/` (base.h, samurai)
 3. **Generate the amalgamated header:**
    ```bash
-   ./scripts/run-amalgam.sh
+	cc amalgam-script.c -o amalgam-script -w # compile amalgam-script.c
+	./amalgam-script
    ```
    This script combines all source files into the single `mate.h` header.
 4. **Test your changes:**

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -81,8 +81,8 @@ You can contribute based on our existing [TODOS](../TODOS.md) or from our [issue
    - Vendor packages are automatically managed in `./vendor/` (base.h, samurai)
 3. **Generate the amalgamated header:**
    ```bash
-	cc amalgam-script.c -o amalgam-script -w # compile amalgam-script.c
-	./amalgam-script
+   cc amalgam-script.c -o amalgam-script -w # compile amalgam-script.c
+   ./amalgam-script
    ```
    This script combines all source files into the single `mate.h` header.
 4. **Test your changes:**

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,7 @@ orleans.codegen.cs
 MigrationBackup/
 FodyWeavers.xsd
 *.code-workspace
+
+.direnv/
+.envrc
+shell.nix

--- a/mate.h
+++ b/mate.h
@@ -2140,7 +2140,8 @@ typedef StringBuilder FlagBuilder;
 /* --- Build System --- */
 void CreateConfig(MateOptions options);
 
-void StartBuild(void);
+#define StartBuild() StartBuildEx(0, NULL)
+void StartBuildEx(int argc, char *argv[argc]);
 void EndBuild(void);
 
 Executable CreateExecutable(ExecutableOptions executableOptions);
@@ -5262,7 +5263,7 @@ static bool mate_need_rebuild(void) {
   return true;
 }
 
-static void mate_rebuild(void) {
+static void mate_rebuild(int argc, char *argv[argc]) {
   if (mate_state.mate_cache.first_build || !mate_need_rebuild()) {
     return;
   }
@@ -5288,11 +5289,19 @@ static void mate_rebuild(void) {
   rename_error = FileRename(mate_exe_new, mate_exe);
   Assert(rename_error == SUCCESS, "MateRebuild: failed renaming new executable into old: %d", rename_error);
 
-  LogInfo("Rebuild finished, running %s", mate_exe.data);
-  exit(RunCommand(mate_exe));
+  StringBuilder sb = SBCreate(mate_state.arena);
+  SBAdd(&sb, mate_exe);
+
+  for (int i=1; i < argc; i += 1) {
+    const char *s = argv[i];
+    SBAddF(&sb, " %s", s);
+  }
+
+  LogInfo("Rebuild finished, running %s", sb.buffer.data);
+  exit(RunCommand(sb.buffer));
 }
 
-void StartBuild(void) {
+void StartBuildEx(int argc, char *argv[argc]) {
   LogInit();
   if (!mate_state.init_config) {
     mate_set_default_state();
@@ -5302,7 +5311,7 @@ void StartBuild(void) {
 
   Assert(Mkdir(mate_state.build_directory) == SUCCESS, "StartBuild: mkdir failed on making path %s", mate_state.build_directory.data);
   mate_read_cache();
-  mate_rebuild();
+  mate_rebuild(argc, argv);
 }
 
 static void mate_apply_warning_flags(FlagBuilder *fb, Compiler c, FlagWarnings w) {

--- a/mate.h
+++ b/mate.h
@@ -2140,7 +2140,7 @@ typedef StringBuilder FlagBuilder;
 /* --- Build System --- */
 void CreateConfig(MateOptions options);
 
-#define StartBuild() StartBuildEx(0, NULL)
+void StartBuild(void);
 void StartBuildEx(int argc, char *argv[argc]);
 void EndBuild(void);
 
@@ -5292,13 +5292,17 @@ static void mate_rebuild(int argc, char *argv[argc]) {
   StringBuilder sb = SBCreate(mate_state.arena);
   SBAdd(&sb, mate_exe);
 
-  for (int i=1; i < argc; i += 1) {
+  for (size_t i=1; i < (size_t)argc; i++) {
     const char *s = argv[i];
     SBAddF(&sb, " %s", s);
   }
 
   LogInfo("Rebuild finished, running %s", sb.buffer.data);
   exit(RunCommand(sb.buffer));
+}
+
+void StartBuild(void) {
+  StartBuildEx(0, NULL);
 }
 
 void StartBuildEx(int argc, char *argv[argc]) {

--- a/src/api.c
+++ b/src/api.c
@@ -94,7 +94,7 @@ static bool mate_need_rebuild(void) {
   return true;
 }
 
-static void mate_rebuild(void) {
+static void mate_rebuild(int argc, char *argv[argc]) {
   if (mate_state.mate_cache.first_build || !mate_need_rebuild()) {
     return;
   }
@@ -120,11 +120,19 @@ static void mate_rebuild(void) {
   rename_error = FileRename(mate_exe_new, mate_exe);
   Assert(rename_error == SUCCESS, "MateRebuild: failed renaming new executable into old: %d", rename_error);
 
-  LogInfo("Rebuild finished, running %s", mate_exe.data);
-  exit(RunCommand(mate_exe));
+  StringBuilder sb = SBCreate(mate_state.arena);
+  SBAdd(&sb, mate_exe);
+
+  for (int i=1; i < argc; i += 1) {
+    const char *s = argv[i];
+    SBAddF(&sb, " %s", s);
+  }
+
+  LogInfo("Rebuild finished, running %s", sb.buffer.data);
+  exit(RunCommand(sb.buffer));
 }
 
-void StartBuild(void) {
+void StartBuildEx(int argc, char *argv[argc]) {
   LogInit();
   if (!mate_state.init_config) {
     mate_set_default_state();
@@ -134,7 +142,7 @@ void StartBuild(void) {
 
   Assert(Mkdir(mate_state.build_directory) == SUCCESS, "StartBuild: mkdir failed on making path %s", mate_state.build_directory.data);
   mate_read_cache();
-  mate_rebuild();
+  mate_rebuild(argc, argv);
 }
 
 static void mate_apply_warning_flags(FlagBuilder *fb, Compiler c, FlagWarnings w) {

--- a/src/api.c
+++ b/src/api.c
@@ -123,13 +123,17 @@ static void mate_rebuild(int argc, char *argv[argc]) {
   StringBuilder sb = SBCreate(mate_state.arena);
   SBAdd(&sb, mate_exe);
 
-  for (int i=1; i < argc; i += 1) {
+  for (size_t i = 1; i < (size_t)argc; i++) {
     const char *s = argv[i];
     SBAddF(&sb, " %s", s);
   }
 
   LogInfo("Rebuild finished, running %s", sb.buffer.data);
   exit(RunCommand(sb.buffer));
+}
+
+void StartBuild(void) {
+  StartBuildEx(0, NULL);
 }
 
 void StartBuildEx(int argc, char *argv[argc]) {

--- a/src/api.h
+++ b/src/api.h
@@ -155,7 +155,8 @@ typedef StringBuilder FlagBuilder;
 /* --- Build System --- */
 void CreateConfig(MateOptions options);
 
-void StartBuild(void);
+#define StartBuild() StartBuildEx(0, NULL)
+void StartBuildEx(int argc, char *argv[argc]);
 void EndBuild(void);
 
 Executable CreateExecutable(ExecutableOptions executableOptions);

--- a/src/api.h
+++ b/src/api.h
@@ -155,7 +155,7 @@ typedef StringBuilder FlagBuilder;
 /* --- Build System --- */
 void CreateConfig(MateOptions options);
 
-#define StartBuild() StartBuildEx(0, NULL)
+void StartBuild(void);
 void StartBuildEx(int argc, char *argv[argc]);
 void EndBuild(void);
 


### PR DESCRIPTION
## Description
So I started using this amazing build system but I ran into an issue when I decided to add subcommands. consider the following code:
```c
int main(int argc, char *argv[argc])
{
  bool is_release_build = false;
  bool run_the_program = false;
  if (argc > 1) {
    if (strcmp(argv[1], "release") == 0) is_release_build = true;
    if (strcmp(argv[1], "debug") == 0) is_release_build = false;
    if (strcmp(argv[1], "run") == 0) run_the_program = true;
  }
  StartBuild();
  // ...
}
```
upon executing `./mate release` and when mate.h detects a change in mate.c . after it rebuilds itself and runs itself again it doesn't pass the arguments on to the executable. the problem was this peace of code in `mate_rebuild` function
```c
  String mate_exe     = mate_state.mate_exe; // usess the exe name
  // . . .
  exit(RunCommand(mate_exe)); // here it execute by name. as if you only typed `./mate`
```

the fix was easy. I introduced a new function called `StartBuildEx(int argc, char *argv[argc])` which takes argc and argv of main. and `StartBuild` is just a macro. and then I replaced the last few line of `mate_rebuild` to these
```c
  StringBuilder sb = SBCreate(mate_state.arena);
  SBAdd(&sb, mate_exe);

  for (int i=1; i < argc; i += 1) {
    const char *s = argv[i];
    SBAddF(&sb, " %s", s);
  }

  LogInfo("Rebuild finished, running %s", sb.buffer.data);
  exit(RunCommand(sb.buffer));
```

so after that I can just use `StartBuildEx` instead of `StartBuild` in the first code block
```c
int main(int argc, char *argv[argc])
{
  bool is_release_build = false;
  bool run_the_program = false;
  if (argc > 1) {
    if (strcmp(argv[1], "release") == 0) is_release_build = true;
    if (strcmp(argv[1], "debug") == 0) is_release_build = false;
    if (strcmp(argv[1], "run") == 0) run_the_program = true;
  }
  StartBuildEx(argc, argv);
  // ...
}
```

### So why a new function?
because changing the arguments of `StartBuild` would be a breaking change. but I think that `StartBuildEx` should be the default #:eyes: 

### Why did you name it StartBuildEx
Pretty much inspired by raylib. I've read that the design of the api is inspired from raylib and clay so I thought it would be a nice touch :)

## Docs
- Updated `CONTRIBUTING.md` to show the new way of using `amalgam-script.c`

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Do you follow our [contribution](./CONTRIBUTING.md) guidelines?
- [x] Yes
- [ ] No [If so why?]
