### PR TITLE
feat: add `rebuild_flags` option to `MateOptions`

### DIFF
--- a/examples/02-custom-config/mate.c
+++ b/examples/02-custom-config/mate.c
@@ -6,7 +6,7 @@ int main(void) {
   CreateConfig((MateOptions){
     .compiler = CLANG,
     .buildDirectory = "./custom-dir",
-    .rebuild_flags = "-w", // custom rebuild flags (used when mate rebuilds itself). useful when you want to ignore all warnings from the build script
+    .rebuildFlags = "-w", // custom rebuild flags (used when mate rebuilds itself). useful when you want to ignore all warnings from the build script
   });
 
   StartBuild();

--- a/examples/02-custom-config/mate.c
+++ b/examples/02-custom-config/mate.c
@@ -3,7 +3,11 @@
 
 int main(void) {
   // You can create a config that allows you to use different compilers as well as build directories
-  CreateConfig((MateOptions){.compiler = CLANG, .buildDirectory = "./custom-dir"});
+  CreateConfig((MateOptions){
+    .compiler = CLANG,
+    .buildDirectory = "./custom-dir",
+    .rebuild_flags = "-w", // custom rebuild flags (used when mate rebuilds itself). useful when you want to ignore all warnings from the build script
+  });
 
   StartBuild();
   {

--- a/mate.h
+++ b/mate.h
@@ -2017,6 +2017,7 @@ typedef struct {
   char *buildDirectory;
   char *mateSource;
   char *mateExe;
+  char *rebuild_flags;
 } MateOptions;
 
 typedef struct {
@@ -2049,6 +2050,7 @@ typedef struct {
   String build_directory;
   String mate_source;
   String mate_exe;
+  String rebuild_flags;
 
   String cwd;
   MateCache mate_cache;
@@ -2064,7 +2066,7 @@ typedef struct {
 typedef enum {
   FLAG_WARNINGS_NONE = 1, // -w
   FLAG_WARNINGS_MINIMAL,  // -Wall
-  FLAG_WARNINGS,          // -Wall -Wextra
+  FLAG_WARNINGS,         // -Wall -Wextra
   FLAG_WARNINGS_VERBOSE,  // -Wall -Wextra -Wpedantic
 } FlagWarnings;
 
@@ -5191,10 +5193,11 @@ static void mate_set_default_state(void) {
 
 void CreateConfig(MateOptions options) {
   mate_set_default_state();
-  if (options.compiler != 0) mate_state.compiler = options.compiler;
-  if (options.mateExe != NULL) mate_state.mate_exe = AbsoluteNormPathExe(s(options.mateExe));
-  if (options.mateSource != NULL) mate_state.mate_source = AbsoluteNormPath(s(options.mateSource));
+  if (options.compiler != 0)          mate_state.compiler = options.compiler;
+  if (options.mateExe != NULL)        mate_state.mate_exe = AbsoluteNormPathExe(s(options.mateExe));
+  if (options.mateSource != NULL)     mate_state.mate_source = AbsoluteNormPath(s(options.mateSource));
   if (options.buildDirectory != NULL) mate_state.build_directory = AbsoluteNormPath(s(options.buildDirectory));
+  if (options.rebuild_flags != NULL)  mate_state.rebuild_flags = s(options.rebuild_flags);
 }
 
 static void mate_read_cache(void) {
@@ -5274,9 +5277,9 @@ static void mate_rebuild(int argc, char **argv) {
 
   String compile_command;
   if (isMSVC()) {
-    compile_command = F(mate_state.arena, "cl.exe \"%s\" /Fe:\"%s\"", mate_state.mate_source.data, mate_exe_new.data);
+    compile_command = F(mate_state.arena, "cl.exe \"%s\" /Fe:\"%s\" %s", mate_state.mate_source.data, mate_exe_new.data, mate_state.rebuild_flags.data);
   } else {
-    compile_command = F(mate_state.arena, "%s \"%s\" -o \"%s\"", CompilerToStr(mate_state.compiler).data, mate_state.mate_source.data, mate_exe_new.data);
+    compile_command = F(mate_state.arena, "%s \"%s\" -o \"%s\" %s", CompilerToStr(mate_state.compiler).data, mate_state.mate_source.data, mate_exe_new.data, mate_state.rebuild_flags.data);
   }
 
   LogWarn("%s changed rebuilding...", mate_state.mate_source.data);

--- a/mate.h
+++ b/mate.h
@@ -2017,7 +2017,7 @@ typedef struct {
   char *buildDirectory;
   char *mateSource;
   char *mateExe;
-  char *rebuild_flags;
+  char *rebuildFlags;
 } MateOptions;
 
 typedef struct {
@@ -5197,7 +5197,11 @@ void CreateConfig(MateOptions options) {
   if (options.mateExe != NULL)        mate_state.mate_exe = AbsoluteNormPathExe(s(options.mateExe));
   if (options.mateSource != NULL)     mate_state.mate_source = AbsoluteNormPath(s(options.mateSource));
   if (options.buildDirectory != NULL) mate_state.build_directory = AbsoluteNormPath(s(options.buildDirectory));
-  if (options.rebuild_flags != NULL)  mate_state.rebuild_flags = s(options.rebuild_flags);
+  if (options.rebuildFlags != NULL) {
+    mate_state.rebuild_flags = s(options.rebuildFlags);
+  } else {
+    mate_state.rebuild_flags = S("");
+  }
 }
 
 static void mate_read_cache(void) {

--- a/src/api.c
+++ b/src/api.c
@@ -15,6 +15,7 @@ static void mate_set_default_state(void) {
     mate_state.mate_exe = AbsoluteNormPathExe(S("./mate"));
     mate_state.mate_source = AbsoluteNormPath(S("./mate.c"));
     mate_state.build_directory = AbsoluteNormPath(S("./build"));
+		mate_state.rebuild_flags = S("");
   }
 
   mate_state.init_config = true;
@@ -26,7 +27,7 @@ void CreateConfig(MateOptions options) {
   if (options.mateExe != NULL)        mate_state.mate_exe = AbsoluteNormPathExe(s(options.mateExe));
   if (options.mateSource != NULL)     mate_state.mate_source = AbsoluteNormPath(s(options.mateSource));
   if (options.buildDirectory != NULL) mate_state.build_directory = AbsoluteNormPath(s(options.buildDirectory));
-  if (options.rebuild_flags != NULL)  mate_state.rebuild_flags = s(options.rebuild_flags);
+  if (options.rebuildFlags != NULL)   mate_state.rebuild_flags = s(options.rebuildFlags);
 }
 
 static void mate_read_cache(void) {

--- a/src/api.c
+++ b/src/api.c
@@ -22,10 +22,11 @@ static void mate_set_default_state(void) {
 
 void CreateConfig(MateOptions options) {
   mate_set_default_state();
-  if (options.compiler != 0) mate_state.compiler = options.compiler;
-  if (options.mateExe != NULL) mate_state.mate_exe = AbsoluteNormPathExe(s(options.mateExe));
-  if (options.mateSource != NULL) mate_state.mate_source = AbsoluteNormPath(s(options.mateSource));
+  if (options.compiler != 0)          mate_state.compiler = options.compiler;
+  if (options.mateExe != NULL)        mate_state.mate_exe = AbsoluteNormPathExe(s(options.mateExe));
+  if (options.mateSource != NULL)     mate_state.mate_source = AbsoluteNormPath(s(options.mateSource));
   if (options.buildDirectory != NULL) mate_state.build_directory = AbsoluteNormPath(s(options.buildDirectory));
+  if (options.rebuild_flags != NULL)  mate_state.rebuild_flags = s(options.rebuild_flags);
 }
 
 static void mate_read_cache(void) {
@@ -105,9 +106,9 @@ static void mate_rebuild(int argc, char **argv) {
 
   String compile_command;
   if (isMSVC()) {
-    compile_command = F(mate_state.arena, "cl.exe \"%s\" /Fe:\"%s\"", mate_state.mate_source.data, mate_exe_new.data);
+    compile_command = F(mate_state.arena, "cl.exe \"%s\" /Fe:\"%s\" %s", mate_state.mate_source.data, mate_exe_new.data, mate_state.rebuild_flags.data);
   } else {
-    compile_command = F(mate_state.arena, "%s \"%s\" -o \"%s\"", CompilerToStr(mate_state.compiler).data, mate_state.mate_source.data, mate_exe_new.data);
+    compile_command = F(mate_state.arena, "%s \"%s\" -o \"%s\" %s", CompilerToStr(mate_state.compiler).data, mate_state.mate_source.data, mate_exe_new.data, mate_state.rebuild_flags.data);
   }
 
   LogWarn("%s changed rebuilding...", mate_state.mate_source.data);

--- a/src/api.h
+++ b/src/api.h
@@ -32,6 +32,7 @@ typedef struct {
   char *buildDirectory;
   char *mateSource;
   char *mateExe;
+  char *rebuild_flags;
 } MateOptions;
 
 typedef struct {
@@ -64,6 +65,7 @@ typedef struct {
   String build_directory;
   String mate_source;
   String mate_exe;
+  String rebuild_flags;
 
   String cwd;
   MateCache mate_cache;
@@ -79,7 +81,7 @@ typedef struct {
 typedef enum {
   FLAG_WARNINGS_NONE = 1, // -w
   FLAG_WARNINGS_MINIMAL,  // -Wall
-  FLAG_WARNINGS,          // -Wall -Wextra
+  FLAG_WARNINGS,         // -Wall -Wextra
   FLAG_WARNINGS_VERBOSE,  // -Wall -Wextra -Wpedantic
 } FlagWarnings;
 

--- a/src/api.h
+++ b/src/api.h
@@ -32,7 +32,7 @@ typedef struct {
   char *buildDirectory;
   char *mateSource;
   char *mateExe;
-  char *rebuild_flags;
+  char *rebuildFlags;
 } MateOptions;
 
 typedef struct {


### PR DESCRIPTION
## Description
I was working with mate.h and and when it rebuild itself it shows me warning in `mate.c` which just flooded my output with unnecessary noise. so I added `rebuild_flags` field to `MateOptions` (check [examples/02-custom-config/mate.c](examples/02-custom-config/mate.c))

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
<img width="884" height="87" alt="image" src="https://github.com/user-attachments/assets/1687f45e-930c-4945-ad4c-ee5daedaa6da" />

## Do you follow our [contribution](./CONTRIBUTING.md) guidelines?
- [x] Yes
- [ ] No [If so why?]
